### PR TITLE
DM-38190: Write up discussion about failure modes in Prompt Processing

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -10,6 +10,8 @@
 
    **This technote is a work-in-progress.**
 
+.. _abstract:
+
 Abstract
 ========
 
@@ -19,11 +21,50 @@ As such, it must be highly robust to algorithmic, network, and infrastructure fa
 
 .. _DMTN-219: https://dmtn-219.lsst.io/
 
-Add content here
-================
+.. _pp-overview:
 
-Add content here.
-See the `reStructuredText Style Guide <https://developer.lsst.io/restructuredtext/style.html>`__ to learn how to create sections, links, images, tables, equations, and more.
+Prompt Processing System Overview
+=================================
+
+.. _general-priorities:
+
+General Priorities
+==================
+
+.. _retries:
+
+Retrying Processing
+===================
+
+.. _association:
+
+APDB and Source Association
+===========================
+
+.. _consistency:
+
+Inconsistent Output
+===================
+
+.. _bad-data:
+
+Corrupted Pipeline Outputs
+==========================
+
+.. _timeout:
+
+Pipeline Timeouts
+=================
+
+.. _major-downtime:
+
+System Downtime
+===============
+
+.. _summary:
+
+Summary
+=======
 
 .. Make in-text citations with: :cite:`bibkey`.
 .. Uncomment to use citations

--- a/index.rst
+++ b/index.rst
@@ -13,7 +13,11 @@
 Abstract
 ========
 
-The Prompt Processing system will be responsible for processing roughly a thousand visits per night, and distributing the results in near real time, for at least ten years of Rubin Observatory operations. As such, it must be highly robust to algorithmic, network, and infrastructure failures, ranging from momentary glitches to extended downtimes. `DMTN-219 <https://dmtn-219.lsst.io/>`_ introduced the initial design for the Prompt Processing framework; this document expands on the design to address expected failure modes and recovery strategies for each.
+The Prompt Processing system will be responsible for processing roughly a thousand visits per night, and distributing the results in near real time, for at least ten years of Rubin Observatory operations.
+As such, it must be highly robust to algorithmic, network, and infrastructure failures, ranging from momentary glitches to extended downtimes.
+`DMTN-219`_ introduced the initial design for the Prompt Processing framework; this document expands on the design to address expected failure modes and recovery strategies for each.
+
+.. _DMTN-219: https://dmtn-219.lsst.io/
 
 Add content here
 ================

--- a/index.rst
+++ b/index.rst
@@ -189,10 +189,26 @@ Flushing the event queue when the Prompt Processing service starts will prevent 
 
 .. _DMTN-248: https://dmtn-248.lsst.io/
 
-.. _summary:
+.. _future:
 
-Summary
-=======
+Future Work
+===========
+
+We will continue revising our error-handling strategies as we gain more experience running the pipeline in real time, and as other parts of the system are clarified.
+
+APDB History
+------------
+
+In early discussions, we considered adding validity ranges to all APDB tables so that the information could be used to make retroactive corrections to the database.
+However, the proposal was dropped on the grounds that validities are intended to mark out-of-date, not erroneous, information.
+However, augmenting the APDB schema with an eye to improving the APDB's robustness is still on the table.
+
+Daytime Corrections
+-------------------
+
+This note assumes that daytime processing will be able to "catch up" on any visits that failed during prompt processing or that were missed because of system downtime.
+It further assumes that the outputs of such processing can be smoothly integrated into the APDB and the central repo.
+However, the exact capabilities of daytime processing are still unclear, and in particular interaction with the APDB will need to be handled carefully.
 
 .. Make in-text citations with: :cite:`bibkey`.
 .. Uncomment to use citations

--- a/index.rst
+++ b/index.rst
@@ -122,6 +122,20 @@ If we (and science users) think of out-of-order visits as precoveries, then ther
 Inconsistent Output
 ===================
 
+As noted in :ref:`general-priorities`, the most important pipeline outputs are, in order, the APDB, the alert stream, and the central repository and metrics.
+As of October 2023, this is also the order in which the pipeline produces outputs.
+If pipeline processing fails in its late stages, these outputs may be inconsistent with each other; for example, the APDB may contain DiaSources for which alerts were never sent.
+
+The alert stream can be easily restored from the APDB, which contains a (possibly incomplete) record of which alerts were sent.
+The reverse conversion is unsafe, because injecting associations after other visits have been processed could lead to contradictory source association histories (see :ref:`association`).
+
+The central repository can itself acquire inconsistencies in two ways.
+First, we will try to transfer the outputs from failed (i.e., incomplete) pipelines, as these may help in diagnosing the problem.
+Such a strategy is safe so long as no code assumes that the existence of one dataset implies the existence of another.
+Second, the central repository sync itself may fail, leaving an undefined subset of datasets transferred.
+Again, the immediate risk is that something might assume the repository contains a self-consistent set of outputs; in the longer term, the datasets can be regenerated through daytime processing.
+
+
 .. _bad-data:
 
 Corrupted Pipeline Outputs

--- a/index.rst
+++ b/index.rst
@@ -26,6 +26,28 @@ As such, it must be highly robust to algorithmic, network, and infrastructure fa
 Prompt Processing System Overview
 =================================
 
+The Prompt Processing system will receive images from LATISS, LSSTComCam, and LSSTCam, and run one of several pipelines on them, depending on the purpose of the observations.
+In the baseline case (running the full Alert Production pipeline on images for the Legacy Survey of Space and Time), the system will create multiple outputs: the transient alert stream, the alert production database (APDB), datasets in a central repository (including the prompt data products described in the `DPDD`_), and Sasquatch metrics for pipeline analytics and debugging.
+
+.. _DPDD: https://lse-163.lsst.io/
+
+As of October 2023, the Prompt Processing system starts processing when it receives a ``next_visit`` event from the summit before observations are taken.
+The event is received by a fan-out service, which forwards a derived event for each detector to a pool of workers.
+Each fanned-out event represents the exposure(s) for a given visit with a given detector.
+Because the workers handle their assigned exposures independently and in parallel, this framework is efficient and flexible with respect to unexpected computational demands.
+However, it's impossible to make assumptions about the order of events between workers, and any given worker may be created or destroyed at any time.
+
+Each of the several hundred workers maintains an internal ("local") Butler repository for its processing; this keeps the central repository from becoming a performance bottleneck for pipeline execution.
+On receiving its visit-detector assignment, each worker downloads any calibrations, templates, etc. it will need but does not yet have from the central repo.
+The worker then waits for the raw exposures to arrive at USDF (or confirms they already arrived) and downloads and ingests them.
+When all exposures have arrived, the worker runs the pipeline, updating the APDB and sending alerts as appropriate; if not all exposures arrive before a timeout, it attempts to process what it has.
+Once pipeline processing is complete, the worker uploads its output datasets to the central repository.
+The worker will likely also compute metrics at this stage, but the details (in particular, whether they are computed before or after the central repository sync) have not yet been decided.
+
+For performance reasons, each worker places pipeline outputs from all visits into a small number of Butler runs, which are persisted when each worker uploads to the central repository.
+The run name is a deterministic function of the Science Pipelines configuration, the instrument and choice of pipeline, and the processing date.
+The use of a separate run for each pipeline is required by the Gen 3 provenance system (in particular, the storage of pipeline configuration information and "init-output" datasets), but makes it difficult for the Prompt Processing system to adjust its choice of pipeline in response to missing inputs or to processing failures.
+
 .. _general-priorities:
 
 General Priorities

--- a/index.rst
+++ b/index.rst
@@ -54,7 +54,7 @@ General Priorities
 ==================
 
 Of the outputs produced by the Alert Production pipeline, the most important to have correct and uncorrupted is the APDB, which serves as the source of truth both for later processing and for the externally available Prompt Products database.
-The alert stream is a close second, since it is the primary user interface for transient follow-up, and while erroneous alerts can be retracted, they may trigger other actions in the meantime.
+The alert stream is a close second, since it is the primary user interface for transient follow-up, and while erroneous alerts can be retracted (see :ref:`bad-data`), they may trigger other actions in the meantime.
 The central repository and metrics are less important: while the repository is the source of processed visit images (PVIs) and difference images for science users, all other data products are exclusively for internal use.
 
 As far as possible, the Prompt Processing pipeline should be idempotent -- in other words, multiple tries of the same pipeline on the same dataset should yield the same results, no matter what the state of the system.
@@ -140,6 +140,22 @@ Again, the immediate risk is that something might assume the repository contains
 
 Corrupted Pipeline Outputs
 ==========================
+
+It's possible that some processing errors will allow the pipeline to run to completion while producing large numbers of invalid sources.
+Such sources will clutter the alert stream with false positives, and may confuse source association on later visits.
+
+The Prompt Processing framework does not itself have any way to detect nonsense output.
+However, the Alert Production team is incorporating "circuit breaker" checks into the pipeline; see `DM-37142`_ and its follow-up issues.
+These checks will escalate suspicious outputs into pipeline failures, which can be handled as described above.
+As of October 2023, the proposed checks focus on poor-quality raw inputs; there are no checks specifically guarding DiaSource detection or the APDB.
+
+.. _DM-37142: https://jira.lsstcorp.org/browse/DM-37142
+
+If invalid sources are reported through the alert stream, a way to retract alerts will be useful.
+Such a design is described in `DMTN-259`_.
+It's out of scope for this note, since retraction will require human intervention and cannot be done at processing time.
+
+.. _DMTN-259: https://dmtn-259.lsst.io/
 
 .. _timeout:
 

--- a/index.rst
+++ b/index.rst
@@ -53,6 +53,14 @@ The use of a separate run for each pipeline is required by the Gen 3 provenance 
 General Priorities
 ==================
 
+Of the outputs produced by the Alert Production pipeline, the most important to have correct and uncorrupted is the APDB, which serves as the source of truth both for later processing and for the externally available Prompt Products database.
+The alert stream is a close second, since it is the primary user interface for transient follow-up, and while erroneous alerts can be retracted, they may trigger other actions in the meantime.
+The central repository and metrics are less important: while the repository is the source of processed visit images (PVIs) and difference images for science users, all other data products are exclusively for internal use.
+
+As far as possible, the Prompt Processing pipeline should be idempotent -- in other words, multiple tries of the same pipeline on the same dataset should yield the same results, no matter what the state of the system.
+This is possible when rebroadcasting the alert stream -- in the worst case, duplicate alerts exist but have the same position and time -- and when running the pipeline from ISR through image differencing.
+However, for reasons explored in :ref:`association`, idempotence cannot be safely achieved with source association.
+
 .. _retries:
 
 Retrying Processing

--- a/index.rst
+++ b/index.rst
@@ -4,11 +4,6 @@
 
 .. Metadata such as the title, authors, and description are set in metadata.yaml
 
-.. TODO: Delete the note below before merging new content to the main branch.
-
-.. note::
-
-   **This technote is a work-in-progress.**
 
 .. _abstract:
 

--- a/index.rst
+++ b/index.rst
@@ -162,6 +162,17 @@ It's out of scope for this note, since retraction will require human interventio
 Pipeline Timeouts
 =================
 
+Another risk is that, under some circumstances, the pipeline code may fail to terminate.
+This risk is mitigated by the scalable processing framework; taking a single worker out of action will not interfere with the processing of other images or with overall system performance.
+
+The obvious way to handle stuck pipelines is to impose a timeout on either the job or the worker.
+The former carries the risk that the worker will be left in an inconsistent state, corrupting future processing.
+The latter adds the overhead of starting a new worker and preparing its local repository, and (depending on the pipeline state and shutdown handling) risks losing all intermediate data.
+In either case, the possibility of a timeout needs to be accounted for when solving the problems discussed in :ref:`association` and :ref:`consistency`, since a timeout can interrupt processing at *any* time, including during I/O.
+
+It might be possible to impose a timeout at the task level rather than the worker level, to better distinguish between a slow job and a stuck one.
+However, no current framework allows tasks to be timed in real time; for example, timing metrics are only available after a task has completed.
+
 .. _major-downtime:
 
 System Downtime

--- a/index.rst
+++ b/index.rst
@@ -178,6 +178,17 @@ However, no current framework allows tasks to be timed in real time; for example
 System Downtime
 ===============
 
+All of the above assumes that failures are single events -- an exception from a single task, a network glitch, an invalid DiaObject.
+However, it's also possible that the system itself will fail for periods much longer than the minute or so it takes to process an image.
+For example, the summit link may be cut, or USDF servers may go offline.
+
+Recovering from such outages will be the responsibility of daytime processing rather than the Prompt Processing framework.
+This catch-up processing will need to create its own alerts, per `DMTN-248`_, and update the APDB accordingly.
+The main concern for Prompt Processing will be ensuring that any ``next_visit`` messages posted during system downtime don't overload it.
+Flushing the event queue when the Prompt Processing service starts will prevent this.
+
+.. _DMTN-248: https://dmtn-248.lsst.io/
+
 .. _summary:
 
 Summary

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -18,6 +18,10 @@ doc_title: "Failure Modes and Error Handling for Prompt Processing"
 # Author names, ordered as a list. Each author name should be formatted as 'First Last'
 authors:
   - "Krzysztof Findeisen"
+  - "Kian-Tat Lim"
+  - "Eric Bellm"
+  - "Hsin-Fang Chiang"
+  - "John Parejko"
 
 # Current document revision date, YYYY-MM-DD
 # Only set this field if you need to manually fix the revision date;


### PR DESCRIPTION
This PR fleshes out a technical note summarizing the design discussion from [DM-36792](https://jira.lsstcorp.org/browse/DM-36792). It includes updates for changes to the situation since last November.

The built documentation is at https://dmtn-260.lsst.io/v/DM-38190/.